### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
             "PyYAML",
             "tls_client",
             "clipman",
-            "playsound",
+            "playsound==1.2.2",
             "ollama",
             "pillow",
             "bson",


### PR DESCRIPTION
The package required to install Playsound must be version 1.2.2. Please verify the version, correct it if necessary, or accept the pull request.