### PR TITLE
Improve TTI provider reliability

### DIFF
--- a/webscout/Provider/OPENAI/autoproxy.py
+++ b/webscout/Provider/OPENAI/autoproxy.py
@@ -2,38 +2,73 @@
 # This module provides a singleton proxy pool for all providers
 
 import proxyfox
+import requests
 
-def get_auto_proxy(protocol='https', country=None, max_speed_ms=1000):
+
+def get_auto_proxy(
+    protocol: str = "https",
+    country: str | None = None,
+    max_speed_ms: int = 1000,
+    *,
+    test_url: str = "https://www.google.com",
+    timeout: int = 5,
+    attempts: int = 5,
+) -> str:
+    """Return a verified working proxy string using ProxyFox.
+
+    The function fetches a proxy from ProxyFox and optionally verifies it
+    by making a request to ``test_url``.  If verification fails, a new proxy
+    is fetched until ``attempts`` is exhausted.
     """
-    Returns a single proxy string (e.g. '11.22.33.44:8080') using proxyfox.
-    You can specify protocol, country, and max_speed_ms for filtering.
-    """
-    kwargs = {'protocol': protocol, 'max_speed_ms': max_speed_ms}
+
+    kwargs = {"protocol": protocol, "max_speed_ms": max_speed_ms}
     if country:
-        kwargs['country'] = country
-    return proxyfox.get_one(**kwargs)
+        kwargs["country"] = country
+
+    last_error: Exception | None = None
+    for _ in range(max(attempts, 1)):
+        proxy = proxyfox.get_one(**kwargs)
+        if not test_url:
+            return proxy
+
+        try:
+            requests.get(
+                test_url,
+                proxies={"http": proxy, "https": proxy},
+                timeout=timeout,
+            )
+            return proxy
+        except Exception as exc:  # pragma: no cover - network dependent
+            last_error = exc
+
+    raise RuntimeError(f"Unable to obtain working proxy: {last_error}")
+
 
 # Optionally: pool support for advanced usage
 _pool = None
 
-def get_proxy_pool(size=10, refresh_interval=300, protocol='https', max_speed_ms=1000):
+
+def get_proxy_pool(size=10, refresh_interval=300, protocol="https", max_speed_ms=1000):
     global _pool
     if _pool is None:
         _pool = proxyfox.create_pool(
             size=size,
             refresh_interval=refresh_interval,
             protocol=protocol,
-            max_speed_ms=max_speed_ms
+            max_speed_ms=max_speed_ms,
         )
     return _pool
+
 
 def get_pool_proxy():
     pool = get_proxy_pool()
     return pool.get()
 
+
 def get_all_pool_proxies():
     pool = get_proxy_pool()
     return pool.all()
+
 
 if __name__ == "__main__":
     print(get_auto_proxy())

--- a/webscout/Provider/TTI/aiarta.py
+++ b/webscout/Provider/TTI/aiarta.py
@@ -13,7 +13,11 @@ Examples:
 
 import requests
 from typing import Optional, List, Dict, Any
-from webscout.Provider.TTI.utils import ImageData, ImageResponse
+from webscout.Provider.TTI.utils import (
+    ImageData,
+    ImageResponse,
+    request_with_proxy_fallback,
+)
 from webscout.Provider.TTI.base import TTICompatibleProvider, BaseImages
 from io import BytesIO
 import os
@@ -27,8 +31,9 @@ try:
 except ImportError:
     Image = None
 
+
 class Images(BaseImages):
-    def __init__(self, client: 'AIArta'):
+    def __init__(self, client: "AIArta"):
         self._client = client
 
     def create(
@@ -44,7 +49,7 @@ class Images(BaseImages):
         aspect_ratio: str = "1:1",
         timeout: int = 60,
         image_format: str = "png",
-        **kwargs
+        **kwargs,
     ) -> ImageResponse:
         """
         image_format: "png" or "jpeg"
@@ -61,32 +66,35 @@ class Images(BaseImages):
             for attempt in range(max_retries):
                 tmp_path = None
                 try:
-                    with tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=False) as tmp:
+                    with tempfile.NamedTemporaryFile(
+                        suffix=f".{ext}", delete=False
+                    ) as tmp:
                         tmp.write(img_bytes)
                         tmp.flush()
                         tmp_path = tmp.name
-                    with open(tmp_path, 'rb') as f:
-                        files = {
-                            'fileToUpload': (f'image.{ext}', f, f'image/{ext}')
-                        }
-                        data = {
-                            'reqtype': 'fileupload',
-                            'json': 'true'
-                        }
-                        headers = {'User-Agent': agent.random()}
+                    with open(tmp_path, "rb") as f:
+                        files = {"fileToUpload": (f"image.{ext}", f, f"image/{ext}")}
+                        data = {"reqtype": "fileupload", "json": "true"}
+                        headers = {"User-Agent": agent.random()}
                         if attempt > 0:
-                            headers['Connection'] = 'close'
-                        resp = requests.post("https://catbox.moe/user/api.php", files=files, data=data, headers=headers, timeout=timeout)
+                            headers["Connection"] = "close"
+                        resp = requests.post(
+                            "https://catbox.moe/user/api.php",
+                            files=files,
+                            data=data,
+                            headers=headers,
+                            timeout=timeout,
+                        )
                         if resp.status_code == 200 and resp.text.strip():
                             text = resp.text.strip()
-                            if text.startswith('http'):
+                            if text.startswith("http"):
                                 return text
                             try:
                                 result = resp.json()
                                 if "url" in result:
                                     return result["url"]
                             except json.JSONDecodeError:
-                                if 'http' in text:
+                                if "http" in text:
                                     return text
                 except Exception:
                     if attempt < max_retries - 1:
@@ -109,12 +117,12 @@ class Images(BaseImages):
                 try:
                     if not os.path.isfile(tmp_path):
                         return None
-                    with open(tmp_path, 'rb') as img_file:
-                        files = {'file': img_file}
-                        response = requests.post('https://0x0.st', files=files)
+                    with open(tmp_path, "rb") as img_file:
+                        files = {"file": img_file}
+                        response = requests.post("https://0x0.st", files=files)
                         response.raise_for_status()
                         image_url = response.text.strip()
-                        if not image_url.startswith('http'):
+                        if not image_url.startswith("http"):
                             return None
                         return image_url
                 except Exception:
@@ -140,7 +148,9 @@ class Images(BaseImages):
             style_value = self._client.get_model(model)
             image_payload = {
                 "prompt": str(prompt),
-                "negative_prompt": str(kwargs.get("negative_prompt", "blurry, deformed hands, ugly")),
+                "negative_prompt": str(
+                    kwargs.get("negative_prompt", "blurry, deformed hands, ugly")
+                ),
                 "style": str(style_value),
                 "images_num": str(1),  # Generate one image at a time in the loop
                 "cfg_scale": str(kwargs.get("guidance_scale", 7)),
@@ -148,14 +158,18 @@ class Images(BaseImages):
                 "aspect_ratio": str(aspect_ratio),
             }
             # Step 2: Generate Image (send as form data, not JSON)
-            image_response = self._client.session.post(
+            image_response = request_with_proxy_fallback(
+                self._client.session,
+                "post",
                 self._client.image_generation_url,
                 data=image_payload,  # Use form data instead of JSON
                 headers=gen_headers,
-                timeout=timeout
+                timeout=timeout,
             )
             if image_response.status_code != 200:
-                raise RuntimeError(f"AIArta API error {image_response.status_code}: {image_response.text}\nPayload: {image_payload}")
+                raise RuntimeError(
+                    f"AIArta API error {image_response.status_code}: {image_response.text}\nPayload: {image_payload}"
+                )
             image_data = image_response.json()
             record_id = image_data.get("record_id")
             if not record_id:
@@ -163,18 +177,27 @@ class Images(BaseImages):
             # Step 3: Check Generation Status
             status_url = self._client.status_check_url.format(record_id=record_id)
             while True:
-                status_response = self._client.session.get(
+                status_response = request_with_proxy_fallback(
+                    self._client.session,
+                    "get",
                     status_url,
                     headers=gen_headers,
-                    timeout=timeout
+                    timeout=timeout,
                 )
                 status_data = status_response.json()
                 status = status_data.get("status")
                 if status == "DONE":
-                    image_urls = [image["url"] for image in status_data.get("response", [])]
+                    image_urls = [
+                        image["url"] for image in status_data.get("response", [])
+                    ]
                     if not image_urls:
                         raise RuntimeError("No image URLs returned from AIArta")
-                    img_resp = self._client.session.get(image_urls[0], timeout=timeout)
+                    img_resp = request_with_proxy_fallback(
+                        self._client.session,
+                        "get",
+                        image_urls[0],
+                        timeout=timeout,
+                    )
                     img_resp.raise_for_status()
                     img_bytes = img_resp.content
                     # Convert to png or jpeg in memory
@@ -191,11 +214,15 @@ class Images(BaseImages):
                     if response_format == "url":
                         uploaded_url = upload_file_with_retry(img_bytes, image_format)
                         if not uploaded_url:
-                            uploaded_url = upload_file_alternative(img_bytes, image_format)
+                            uploaded_url = upload_file_alternative(
+                                img_bytes, image_format
+                            )
                         if uploaded_url:
                             urls.append(uploaded_url)
                         else:
-                            raise RuntimeError("Failed to upload image to catbox.moe using all available methods")
+                            raise RuntimeError(
+                                "Failed to upload image to catbox.moe using all available methods"
+                            )
                     break
                 elif status in ("IN_QUEUE", "IN_PROGRESS"):
                     time.sleep(2)
@@ -208,6 +235,7 @@ class Images(BaseImages):
                 result_data.append(ImageData(url=url))
         elif response_format == "b64_json":
             import base64
+
             for img in images:
                 b64 = base64.b64encode(img).decode("utf-8")
                 result_data.append(ImageData(b64_json=b64))
@@ -215,10 +243,9 @@ class Images(BaseImages):
             raise ValueError("response_format must be 'url' or 'b64_json'")
 
         from time import time as _time
-        return ImageResponse(
-            created=int(_time()),
-            data=result_data
-        )
+
+        return ImageResponse(created=int(_time()), data=result_data)
+
 
 class AIArta(TTICompatibleProvider):
     # Model aliases mapping from lowercase keys to proper API style names
@@ -269,16 +296,18 @@ class AIArta(TTICompatibleProvider):
         "kawaii": "Kawaii",
         "cinematic_art": "Cinematic Art",
         "professional": "Professional",
-        "black_ink": "Black Ink"
+        "black_ink": "Black Ink",
     }
-    
+
     AVAILABLE_MODELS = list(model_aliases.keys())
     default_model = "Flux"
     default_image_model = default_model
 
     def __init__(self):
         self.image_generation_url = "https://img-gen-prod.ai-arta.com/api/v1/text2image"
-        self.status_check_url = "https://img-gen-prod.ai-arta.com/api/v1/text2image/{record_id}/status"
+        self.status_check_url = (
+            "https://img-gen-prod.ai-arta.com/api/v1/text2image/{record_id}/status"
+        )
         self.auth_url = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/signupNewUser?key=AIzaSyB3-71wG0fIt0shj0ee4fvx1shcjJHGrrQ"
         self.token_refresh_url = "https://securetoken.googleapis.com/v1/token?key=AIzaSyB3-71wG0fIt0shj0ee4fvx1shcjJHGrrQ"
         self.session = requests.Session()
@@ -303,12 +332,19 @@ class AIArta(TTICompatibleProvider):
     def create_token(self, path: str) -> Dict[str, Any]:
         auth_payload = {"clientType": "CLIENT_TYPE_ANDROID"}
         proxies = self.session.proxies if self.session.proxies else None
-        auth_response = self.session.post(self.auth_url, json=auth_payload, timeout=60, proxies=proxies)
+        auth_response = request_with_proxy_fallback(
+            self.session,
+            "post",
+            self.auth_url,
+            json=auth_payload,
+            timeout=60,
+            proxies=proxies,
+        )
         auth_data = auth_response.json()
         auth_token = auth_data.get("idToken")
         if not auth_token:
             raise Exception("Failed to obtain authentication token.")
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             json.dump(auth_data, f)
         return auth_data
 
@@ -317,23 +353,29 @@ class AIArta(TTICompatibleProvider):
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
         }
-        response = self.session.post(self.token_refresh_url, data=payload, timeout=60)
+        response = request_with_proxy_fallback(
+            self.session,
+            "post",
+            self.token_refresh_url,
+            data=payload,
+            timeout=60,
+        )
         response_data = response.json()
         return response_data.get("id_token"), response_data.get("refresh_token")
 
     def read_and_refresh_token(self) -> Dict[str, Any]:
         path = self.get_auth_file()
         if os.path.isfile(path):
-            with open(path, 'r') as f:
+            with open(path, "r") as f:
                 auth_data = json.load(f)
             diff = time.time() - os.path.getmtime(path)
             expires_in = int(auth_data.get("expiresIn", 3600))
             if diff < expires_in:
                 if diff > expires_in / 2:
-                    auth_data["idToken"], auth_data["refreshToken"] = self.refresh_token(
-                        auth_data.get("refreshToken")
+                    auth_data["idToken"], auth_data["refreshToken"] = (
+                        self.refresh_token(auth_data.get("refreshToken"))
                     )
-                    with open(path, 'w') as f:
+                    with open(path, "w") as f:
                         json.dump(auth_data, f)
                 return auth_data
         return self.create_token(path)
@@ -349,11 +391,14 @@ class AIArta(TTICompatibleProvider):
         class _ModelList:
             def list(inner_self):
                 return type(self).AVAILABLE_MODELS
+
         return _ModelList()
+
 
 # Example usage:
 if __name__ == "__main__":
     from rich import print
+
     client = AIArta()
     response = client.images.create(
         model="flux",

--- a/webscout/Provider/TTI/fastflux.py
+++ b/webscout/Provider/TTI/fastflux.py
@@ -2,8 +2,13 @@ import requests
 import os
 import tempfile
 import time
+import base64
 from typing import Optional, List, Dict, Any
-from webscout.Provider.TTI.utils import ImageData, ImageResponse
+from webscout.Provider.TTI.utils import (
+    ImageData,
+    ImageResponse,
+    request_with_proxy_fallback,
+)
 from webscout.Provider.TTI.base import TTICompatibleProvider, BaseImages
 from io import BytesIO
 from webscout.litagent import LitAgent
@@ -13,11 +18,13 @@ try:
 except ImportError:
     Image = None
 
+
 class Images(BaseImages):
     def __init__(self, client):
         self._client = client
 
-    def create(self,
+    def create(
+        self,
         model: str = "flux_1_schnell",
         prompt: str = None,
         n: int = 1,
@@ -29,7 +36,7 @@ class Images(BaseImages):
         timeout: int = 60,
         image_format: str = "png",
         is_public: bool = False,
-        **kwargs
+        **kwargs,
     ) -> ImageResponse:
         if not prompt:
             raise ValueError("Prompt is required!")
@@ -41,15 +48,21 @@ class Images(BaseImages):
             "prompt": prompt,
             "model": model,
             "size": size,
-            "isPublic": is_public
+            "isPublic": is_public,
         }
         for _ in range(n):
-            resp = self._client.session.post(api_url, json=payload, timeout=timeout)
+            resp = request_with_proxy_fallback(
+                self._client.session,
+                "post",
+                api_url,
+                json=payload,
+                timeout=timeout,
+            )
             resp.raise_for_status()
             result = resp.json()
-            if result and 'result' in result:
-                image_data = result['result']
-                base64_data = image_data.split(',')[1]
+            if result and "result" in result:
+                image_data = result["result"]
+                base64_data = image_data.split(",")[1]
                 img_bytes = base64.b64decode(base64_data)
                 # Convert to png or jpeg in memory if needed
                 if Image is not None:
@@ -64,37 +77,47 @@ class Images(BaseImages):
                             img_bytes = out_io.getvalue()
                 images.append(img_bytes)
                 if response_format == "url":
+
                     def upload_file_with_retry(img_bytes, image_format, max_retries=3):
                         ext = "jpg" if image_format.lower() == "jpeg" else "png"
                         for attempt in range(max_retries):
                             tmp_path = None
                             try:
-                                with tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=False) as tmp:
+                                with tempfile.NamedTemporaryFile(
+                                    suffix=f".{ext}", delete=False
+                                ) as tmp:
                                     tmp.write(img_bytes)
                                     tmp.flush()
                                     tmp_path = tmp.name
-                                with open(tmp_path, 'rb') as f:
+                                with open(tmp_path, "rb") as f:
                                     files = {
-                                        'fileToUpload': (f'image.{ext}', f, f'image/{ext}')
+                                        "fileToUpload": (
+                                            f"image.{ext}",
+                                            f,
+                                            f"image/{ext}",
+                                        )
                                     }
-                                    data = {
-                                        'reqtype': 'fileupload',
-                                        'json': 'true'
-                                    }
-                                    headers = {'User-Agent': agent.random()}
+                                    data = {"reqtype": "fileupload", "json": "true"}
+                                    headers = {"User-Agent": agent.random()}
                                     if attempt > 0:
-                                        headers['Connection'] = 'close'
-                                    resp = requests.post("https://catbox.moe/user/api.php", files=files, data=data, headers=headers, timeout=timeout)
+                                        headers["Connection"] = "close"
+                                    resp = requests.post(
+                                        "https://catbox.moe/user/api.php",
+                                        files=files,
+                                        data=data,
+                                        headers=headers,
+                                        timeout=timeout,
+                                    )
                                     if resp.status_code == 200 and resp.text.strip():
                                         text = resp.text.strip()
-                                        if text.startswith('http'):
+                                        if text.startswith("http"):
                                             return text
                                         try:
                                             result = resp.json()
                                             if "url" in result:
                                                 return result["url"]
                                         except Exception:
-                                            if 'http' in text:
+                                            if "http" in text:
                                                 return text
                             except Exception:
                                 if attempt < max_retries - 1:
@@ -106,22 +129,27 @@ class Images(BaseImages):
                                     except Exception:
                                         pass
                         return None
+
                     def upload_file_alternative(img_bytes, image_format):
                         try:
                             ext = "jpg" if image_format.lower() == "jpeg" else "png"
-                            with tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=False) as tmp:
+                            with tempfile.NamedTemporaryFile(
+                                suffix=f".{ext}", delete=False
+                            ) as tmp:
                                 tmp.write(img_bytes)
                                 tmp.flush()
                                 tmp_path = tmp.name
                             try:
                                 if not os.path.isfile(tmp_path):
                                     return None
-                                with open(tmp_path, 'rb') as img_file:
-                                    files = {'file': img_file}
-                                    response = requests.post('https://0x0.st', files=files)
+                                with open(tmp_path, "rb") as img_file:
+                                    files = {"file": img_file}
+                                    response = requests.post(
+                                        "https://0x0.st", files=files
+                                    )
                                     response.raise_for_status()
                                     image_url = response.text.strip()
-                                    if not image_url.startswith('http'):
+                                    if not image_url.startswith("http"):
                                         return None
                                     return image_url
                             except Exception:
@@ -133,13 +161,16 @@ class Images(BaseImages):
                                     pass
                         except Exception:
                             return None
+
                     uploaded_url = upload_file_with_retry(img_bytes, image_format)
                     if not uploaded_url:
                         uploaded_url = upload_file_alternative(img_bytes, image_format)
                     if uploaded_url:
                         urls.append(uploaded_url)
                     else:
-                        raise RuntimeError("Failed to upload image to catbox.moe using all available methods")
+                        raise RuntimeError(
+                            "Failed to upload image to catbox.moe using all available methods"
+                        )
             else:
                 raise RuntimeError("No image data received from FastFlux API")
         result_data = []
@@ -148,21 +179,22 @@ class Images(BaseImages):
                 result_data.append(ImageData(url=url))
         elif response_format == "b64_json":
             import base64
+
             for img in images:
                 b64 = base64.b64encode(img).decode("utf-8")
                 result_data.append(ImageData(b64_json=b64))
         else:
             raise ValueError("response_format must be 'url' or 'b64_json'")
         from time import time as _time
-        return ImageResponse(
-            created=int(_time()),
-            data=result_data
-        )
+
+        return ImageResponse(created=int(_time()), data=result_data)
+
 
 class FastFluxAI(TTICompatibleProvider):
     AVAILABLE_MODELS = [
         "flux_1_schnell",
     ]
+
     def __init__(self, api_key: str = None):
         self.api_endpoint = "https://api.freeflux.ai/v1/images/generate"
         self.session = requests.Session()
@@ -180,15 +212,19 @@ class FastFluxAI(TTICompatibleProvider):
             self.headers["authorization"] = f"Bearer {self.api_key}"
         self.session.headers.update(self.headers)
         self.images = Images(self)
+
     @property
     def models(self):
         class _ModelList:
             def list(inner_self):
                 return type(self).AVAILABLE_MODELS
+
         return _ModelList()
+
 
 if __name__ == "__main__":
     from rich import print
+
     client = FastFluxAI()
     response = client.images.create(
         model="flux_1_schnell",

--- a/webscout/Provider/TTI/imagen.py
+++ b/webscout/Provider/TTI/imagen.py
@@ -1,10 +1,15 @@
 import requests
 import base64
 from typing import Optional, List, Dict, Any
-from webscout.Provider.TTI.utils import ImageData, ImageResponse
+from webscout.Provider.TTI.utils import (
+    ImageData,
+    ImageResponse,
+    request_with_proxy_fallback,
+)
 from webscout.Provider.TTI.base import TTICompatibleProvider, BaseImages
 from webscout.litagent import LitAgent
 import time
+
 
 class Images(BaseImages):
     def __init__(self, client):
@@ -24,11 +29,11 @@ class Images(BaseImages):
         timeout: int = 60,
         image_format: str = "png",
         seed: Optional[int] = None,
-        **kwargs
+        **kwargs,
     ) -> ImageResponse:
         """
         Create images using the Imagen API.
-        
+
         Args:
             model: The model to use (e.g., "imagen_3_5")
             prompt: The text prompt for image generation
@@ -37,39 +42,41 @@ class Images(BaseImages):
             response_format: "url" or "b64_json"
             timeout: Request timeout in seconds
             **kwargs: Additional parameters
-            
+
         Returns:
             ImageResponse: The generated images
         """
         if not prompt:
             raise ValueError("Prompt is required!")
-        
+
         result_data = []
-        
+
         for _ in range(n):
             # Prepare the request payload
             payload = {
                 "prompt": prompt,
                 "model": model,
                 "size": size,
-                "response_format": "url"  # Always request URL from API
+                "response_format": "url",  # Always request URL from API
             }
-            
+
             try:
                 # Make the API request
-                resp = self._client.session.post(
+                resp = request_with_proxy_fallback(
+                    self._client.session,
+                    "post",
                     self._client.api_endpoint,
                     json=payload,
-                    timeout=timeout
+                    timeout=timeout,
                 )
                 resp.raise_for_status()
-                
+
                 # Parse the response
                 result = resp.json()
-                
+
                 if not result or "data" not in result:
                     raise RuntimeError("Invalid response from Imagen API")
-                
+
                 # Process each image in the response
                 for item in result["data"]:
                     if response_format == "url":
@@ -77,11 +84,16 @@ class Images(BaseImages):
                             result_data.append(ImageData(url=item["url"]))
                         else:
                             raise RuntimeError("No URL found in API response")
-                    
+
                     elif response_format == "b64_json":
                         if "url" in item and item["url"]:
                             # Download the image and convert to base64
-                            img_resp = self._client.session.get(item["url"], timeout=timeout)
+                            img_resp = request_with_proxy_fallback(
+                                self._client.session,
+                                "get",
+                                item["url"],
+                                timeout=timeout,
+                            )
                             img_resp.raise_for_status()
                             img_bytes = img_resp.content
                             b64_string = base64.b64encode(img_bytes).decode("utf-8")
@@ -90,39 +102,32 @@ class Images(BaseImages):
                             result_data.append(ImageData(b64_json=item["b64_json"]))
                         else:
                             raise RuntimeError("No image data found in API response")
-                    
+
                     else:
                         raise ValueError("response_format must be 'url' or 'b64_json'")
-                        
+
             except requests.exceptions.RequestException as e:
                 raise RuntimeError(f"Failed to generate image with Imagen API: {e}")
             except Exception as e:
                 raise RuntimeError(f"Error processing Imagen API response: {e}")
-        
-        return ImageResponse(
-            created=int(time.time()),
-            data=result_data
-        )
+
+        return ImageResponse(created=int(time.time()), data=result_data)
 
 
 class ImagenAI(TTICompatibleProvider):
     """
     Imagen API provider for text-to-image generation.
-    
+
     This provider interfaces with the Imagen API at imagen.exomlapi.com
     to generate images from text prompts.
     """
-    
-    AVAILABLE_MODELS = [
-        "imagen_3_5",
-        "imagen_3"
 
-    ]
+    AVAILABLE_MODELS = ["imagen_3_5", "imagen_3"]
 
     def __init__(self, api_key: Optional[str] = None):
         """
         Initialize the Imagen API client.
-        
+
         Args:
             api_key: Optional API key for authentication (if required)
         """
@@ -130,7 +135,7 @@ class ImagenAI(TTICompatibleProvider):
         self.session = requests.Session()
         self.user_agent = LitAgent().random()
         self.api_key = api_key
-        
+
         # Set up headers based on the provided request details
         self.headers = {
             "accept": "*/*",
@@ -149,11 +154,11 @@ class ImagenAI(TTICompatibleProvider):
             "sec-gpc": "1",
             "user-agent": self.user_agent,
         }
-        
+
         # Add API key to headers if provided
         if self.api_key:
             self.headers["authorization"] = f"Bearer {self.api_key}"
-        
+
         self.session.headers.update(self.headers)
         self.images = Images(self)
 
@@ -161,22 +166,24 @@ class ImagenAI(TTICompatibleProvider):
     def models(self):
         """
         Get available models for the Imagen API.
-        
+
         Returns:
             Object with list() method that returns available models
         """
+
         class _ModelList:
             def list(inner_self):
                 return type(self).AVAILABLE_MODELS
+
         return _ModelList()
 
 
 if __name__ == "__main__":
     from rich import print
-    
+
     # Example usage
     client = ImagenAI()
-    
+
     try:
         response = client.images.create(
             model="imagen_3_5",

--- a/webscout/Provider/TTI/magicstudio.py
+++ b/webscout/Provider/TTI/magicstudio.py
@@ -4,7 +4,11 @@ import uuid
 import time
 import tempfile
 from typing import Optional, List
-from webscout.Provider.TTI.utils import ImageData, ImageResponse
+from webscout.Provider.TTI.utils import (
+    ImageData,
+    ImageResponse,
+    request_with_proxy_fallback,
+)
 from webscout.Provider.TTI.base import TTICompatibleProvider, BaseImages
 from io import BytesIO
 from webscout.litagent import LitAgent
@@ -14,11 +18,13 @@ try:
 except ImportError:
     Image = None
 
+
 class Images(BaseImages):
     def __init__(self, client):
         self._client = client
 
-    def create(self,
+    def create(
+        self,
         model: str = "magicstudio",
         prompt: str = None,
         n: int = 1,
@@ -29,7 +35,7 @@ class Images(BaseImages):
         aspect_ratio: str = None,
         timeout: int = 60,
         image_format: str = "jpg",
-        **kwargs
+        **kwargs,
     ) -> ImageResponse:
         if not prompt:
             raise ValueError("Prompt is required!")
@@ -43,7 +49,7 @@ class Images(BaseImages):
             "Origin": "https://magicstudio.com",
             "Referer": "https://magicstudio.com/ai-art-generator/",
             "DNT": "1",
-            "Sec-GPC": "1"
+            "Sec-GPC": "1",
         }
         session = requests.Session()
         session.headers.update(headers)
@@ -57,7 +63,13 @@ class Images(BaseImages):
                 "user_is_subscribed": "false",
                 "client_id": uuid.uuid4().hex,
             }
-            resp = session.post(api_url, data=form_data, timeout=timeout)
+            resp = request_with_proxy_fallback(
+                session,
+                "post",
+                api_url,
+                data=form_data,
+                timeout=timeout,
+            )
             resp.raise_for_status()
             img_bytes = resp.content
             # Convert to png or jpeg in memory if needed
@@ -65,7 +77,10 @@ class Images(BaseImages):
                 with BytesIO(img_bytes) as input_io:
                     with Image.open(input_io) as im:
                         out_io = BytesIO()
-                        if image_format.lower() == "jpeg" or image_format.lower() == "jpg":
+                        if (
+                            image_format.lower() == "jpeg"
+                            or image_format.lower() == "jpg"
+                        ):
                             im = im.convert("RGB")
                             im.save(out_io, format="JPEG")
                         else:
@@ -73,37 +88,43 @@ class Images(BaseImages):
                         img_bytes = out_io.getvalue()
             images.append(img_bytes)
             if response_format == "url":
+
                 def upload_file_with_retry(img_bytes, image_format, max_retries=3):
                     ext = "jpg" if image_format.lower() in ("jpeg", "jpg") else "png"
                     for attempt in range(max_retries):
                         tmp_path = None
                         try:
-                            with tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=False) as tmp:
+                            with tempfile.NamedTemporaryFile(
+                                suffix=f".{ext}", delete=False
+                            ) as tmp:
                                 tmp.write(img_bytes)
                                 tmp.flush()
                                 tmp_path = tmp.name
-                            with open(tmp_path, 'rb') as f:
+                            with open(tmp_path, "rb") as f:
                                 files = {
-                                    'fileToUpload': (f'image.{ext}', f, f'image/{ext}')
+                                    "fileToUpload": (f"image.{ext}", f, f"image/{ext}")
                                 }
-                                data = {
-                                    'reqtype': 'fileupload',
-                                    'json': 'true'
-                                }
-                                headers = {'User-Agent': agent.random()}
+                                data = {"reqtype": "fileupload", "json": "true"}
+                                headers = {"User-Agent": agent.random()}
                                 if attempt > 0:
-                                    headers['Connection'] = 'close'
-                                resp = requests.post("https://catbox.moe/user/api.php", files=files, data=data, headers=headers, timeout=timeout)
+                                    headers["Connection"] = "close"
+                                resp = requests.post(
+                                    "https://catbox.moe/user/api.php",
+                                    files=files,
+                                    data=data,
+                                    headers=headers,
+                                    timeout=timeout,
+                                )
                                 if resp.status_code == 200 and resp.text.strip():
                                     text = resp.text.strip()
-                                    if text.startswith('http'):
+                                    if text.startswith("http"):
                                         return text
                                     try:
                                         result = resp.json()
                                         if "url" in result:
                                             return result["url"]
                                     except Exception:
-                                        if 'http' in text:
+                                        if "http" in text:
                                             return text
                         except Exception:
                             if attempt < max_retries - 1:
@@ -115,22 +136,27 @@ class Images(BaseImages):
                                 except Exception:
                                     pass
                     return None
+
                 def upload_file_alternative(img_bytes, image_format):
                     try:
-                        ext = "jpg" if image_format.lower() in ("jpeg", "jpg") else "png"
-                        with tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=False) as tmp:
+                        ext = (
+                            "jpg" if image_format.lower() in ("jpeg", "jpg") else "png"
+                        )
+                        with tempfile.NamedTemporaryFile(
+                            suffix=f".{ext}", delete=False
+                        ) as tmp:
                             tmp.write(img_bytes)
                             tmp.flush()
                             tmp_path = tmp.name
                         try:
                             if not os.path.isfile(tmp_path):
                                 return None
-                            with open(tmp_path, 'rb') as img_file:
-                                files = {'file': img_file}
-                                alt_resp = requests.post('https://0x0.st', files=files)
+                            with open(tmp_path, "rb") as img_file:
+                                files = {"file": img_file}
+                                alt_resp = requests.post("https://0x0.st", files=files)
                                 alt_resp.raise_for_status()
                                 image_url = alt_resp.text.strip()
-                                if not image_url.startswith('http'):
+                                if not image_url.startswith("http"):
                                     return None
                                 return image_url
                         except Exception:
@@ -142,32 +168,36 @@ class Images(BaseImages):
                                 pass
                     except Exception:
                         return None
+
                 uploaded_url = upload_file_with_retry(img_bytes, image_format)
                 if not uploaded_url:
                     uploaded_url = upload_file_alternative(img_bytes, image_format)
                 if uploaded_url:
                     urls.append(uploaded_url)
                 else:
-                    raise RuntimeError("Failed to upload image to catbox.moe using all available methods")
+                    raise RuntimeError(
+                        "Failed to upload image to catbox.moe using all available methods"
+                    )
         result_data = []
         if response_format == "url":
             for url in urls:
                 result_data.append(ImageData(url=url))
         elif response_format == "b64_json":
             import base64
+
             for img in images:
                 b64 = base64.b64encode(img).decode("utf-8")
                 result_data.append(ImageData(b64_json=b64))
         else:
             raise ValueError("response_format must be 'url' or 'b64_json'")
         from time import time as _time
-        return ImageResponse(
-            created=int(_time()),
-            data=result_data
-        )
+
+        return ImageResponse(created=int(_time()), data=result_data)
+
 
 class MagicStudioAI(TTICompatibleProvider):
     AVAILABLE_MODELS = ["magicstudio"]
+
     def __init__(self):
         self.api_endpoint = "https://ai-api.magicstudio.com/api/ai-art-generator"
         self.session = requests.Session()
@@ -182,15 +212,19 @@ class MagicStudioAI(TTICompatibleProvider):
         }
         self.session.headers.update(self.headers)
         self.images = Images(self)
+
     @property
     def models(self):
         class _ModelList:
             def list(inner_self):
                 return type(self).AVAILABLE_MODELS
+
         return _ModelList()
+
 
 if __name__ == "__main__":
     from rich import print
+
     client = MagicStudioAI()
     response = client.images.create(
         prompt="A cool cyberpunk city at night",

--- a/webscout/Provider/TTI/piclumen.py
+++ b/webscout/Provider/TTI/piclumen.py
@@ -1,6 +1,10 @@
 import requests
 from typing import Optional, List, Dict, Any
-from webscout.Provider.TTI.utils import ImageData, ImageResponse
+from webscout.Provider.TTI.utils import (
+    ImageData,
+    ImageResponse,
+    request_with_proxy_fallback,
+)
 from webscout.Provider.TTI.base import TTICompatibleProvider, BaseImages
 from io import BytesIO
 import os
@@ -14,11 +18,13 @@ try:
 except ImportError:
     Image = None
 
+
 class Images(BaseImages):
     def __init__(self, client):
         self._client = client
 
-    def create(self,
+    def create(
+        self,
         model: str,
         prompt: str,
         n: int = 1,
@@ -29,7 +35,7 @@ class Images(BaseImages):
         aspect_ratio: str = "1:1",
         timeout: int = 60,
         image_format: str = "jpeg",
-        **kwargs
+        **kwargs,
     ) -> ImageResponse:
         """
         image_format: "png" or "jpeg"
@@ -46,32 +52,35 @@ class Images(BaseImages):
             for attempt in range(max_retries):
                 tmp_path = None
                 try:
-                    with tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=False) as tmp:
+                    with tempfile.NamedTemporaryFile(
+                        suffix=f".{ext}", delete=False
+                    ) as tmp:
                         tmp.write(img_bytes)
                         tmp.flush()
                         tmp_path = tmp.name
-                    with open(tmp_path, 'rb') as f:
-                        files = {
-                            'fileToUpload': (f'image.{ext}', f, f'image/{ext}')
-                        }
-                        data = {
-                            'reqtype': 'fileupload',
-                            'json': 'true'
-                        }
-                        headers = {'User-Agent': agent.random()}
+                    with open(tmp_path, "rb") as f:
+                        files = {"fileToUpload": (f"image.{ext}", f, f"image/{ext}")}
+                        data = {"reqtype": "fileupload", "json": "true"}
+                        headers = {"User-Agent": agent.random()}
                         if attempt > 0:
-                            headers['Connection'] = 'close'
-                        resp = requests.post("https://catbox.moe/user/api.php", files=files, data=data, headers=headers, timeout=timeout)
+                            headers["Connection"] = "close"
+                        resp = requests.post(
+                            "https://catbox.moe/user/api.php",
+                            files=files,
+                            data=data,
+                            headers=headers,
+                            timeout=timeout,
+                        )
                         if resp.status_code == 200 and resp.text.strip():
                             text = resp.text.strip()
-                            if text.startswith('http'):
+                            if text.startswith("http"):
                                 return text
                             try:
                                 result = resp.json()
                                 if "url" in result:
                                     return result["url"]
                             except json.JSONDecodeError:
-                                if 'http' in text:
+                                if "http" in text:
                                     return text
                 except Exception:
                     if attempt < max_retries - 1:
@@ -94,12 +103,12 @@ class Images(BaseImages):
                 try:
                     if not os.path.isfile(tmp_path):
                         return None
-                    with open(tmp_path, 'rb') as img_file:
-                        files = {'file': img_file}
-                        response = requests.post('https://0x0.st', files=files)
+                    with open(tmp_path, "rb") as img_file:
+                        files = {"file": img_file}
+                        response = requests.post("https://0x0.st", files=files)
                         response.raise_for_status()
                         image_url = response.text.strip()
-                        if not image_url.startswith('http'):
+                        if not image_url.startswith("http"):
                             return None
                         return image_url
                 except Exception:
@@ -114,14 +123,16 @@ class Images(BaseImages):
 
         for _ in range(n):
             payload = {"prompt": prompt}
-            resp = self._client.session.post(
+            resp = request_with_proxy_fallback(
+                self._client.session,
+                "post",
                 self._client.api_endpoint,
                 json=payload,
-                timeout=timeout
+                timeout=timeout,
             )
             resp.raise_for_status()
             # Piclumen returns image/jpeg directly
-            if resp.headers.get('content-type') == 'image/jpeg':
+            if resp.headers.get("content-type") == "image/jpeg":
                 img_bytes = resp.content
                 # Convert to png or jpeg in memory
                 with BytesIO(img_bytes) as input_io:
@@ -141,7 +152,9 @@ class Images(BaseImages):
                     if uploaded_url:
                         urls.append(uploaded_url)
                     else:
-                        raise RuntimeError("Failed to upload image to catbox.moe using all available methods")
+                        raise RuntimeError(
+                            "Failed to upload image to catbox.moe using all available methods"
+                        )
             else:
                 raise RuntimeError("No image data received from Piclumen")
 
@@ -151,6 +164,7 @@ class Images(BaseImages):
                 result_data.append(ImageData(url=url))
         elif response_format == "b64_json":
             import base64
+
             for img in images:
                 b64 = base64.b64encode(img).decode("utf-8")
                 result_data.append(ImageData(b64_json=b64))
@@ -158,15 +172,12 @@ class Images(BaseImages):
             raise ValueError("response_format must be 'url' or 'b64_json'")
 
         from time import time as _time
-        return ImageResponse(
-            created=int(_time()),
-            data=result_data
-        )
+
+        return ImageResponse(created=int(_time()), data=result_data)
+
 
 class PiclumenAI(TTICompatibleProvider):
-    AVAILABLE_MODELS = [
-        "piclumen-v1"
-    ]
+    AVAILABLE_MODELS = ["piclumen-v1"]
 
     def __init__(self):
         self.api_endpoint = "https://s9.piclumen.art/comfy/api/generate-image"
@@ -188,10 +199,13 @@ class PiclumenAI(TTICompatibleProvider):
         class _ModelList:
             def list(inner_self):
                 return type(self).AVAILABLE_MODELS
+
         return _ModelList()
+
 
 if __name__ == "__main__":
     from rich import print
+
     client = PiclumenAI()
     response = client.images.create(
         model="piclumen-v1",

--- a/webscout/Provider/TTI/pixelmuse.py
+++ b/webscout/Provider/TTI/pixelmuse.py
@@ -1,6 +1,10 @@
 import requests
 from typing import Optional, List, Dict, Any
-from webscout.Provider.TTI.utils import ImageData, ImageResponse
+from webscout.Provider.TTI.utils import (
+    ImageData,
+    ImageResponse,
+    request_with_proxy_fallback,
+)
 from webscout.Provider.TTI.base import TTICompatibleProvider, BaseImages
 from io import BytesIO
 import os
@@ -14,8 +18,9 @@ try:
 except ImportError:
     Image = None
 
+
 class Images(BaseImages):
-    def __init__(self, client: 'PixelMuse'):
+    def __init__(self, client: "PixelMuse"):
         self._client = client
 
     def create(
@@ -31,7 +36,7 @@ class Images(BaseImages):
         aspect_ratio: str = "1:1",
         timeout: int = 60,
         image_format: str = "png",
-        **kwargs
+        **kwargs,
     ) -> ImageResponse:
         """
         image_format: "png" or "jpeg"
@@ -41,39 +46,42 @@ class Images(BaseImages):
 
         images = []
         urls = []
-        
+
         def upload_file_with_retry(img_bytes, image_format, max_retries=3):
             """Upload file with retry logic using requests and tempfile"""
             ext = "jpg" if image_format.lower() == "jpeg" else "png"
             for attempt in range(max_retries):
                 tmp_path = None
                 try:
-                    with tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=False) as tmp:
+                    with tempfile.NamedTemporaryFile(
+                        suffix=f".{ext}", delete=False
+                    ) as tmp:
                         tmp.write(img_bytes)
                         tmp.flush()
                         tmp_path = tmp.name
-                    with open(tmp_path, 'rb') as f:
-                        files = {
-                            'fileToUpload': (f'image.{ext}', f, f'image/{ext}')
-                        }
-                        data = {
-                            'reqtype': 'fileupload',
-                            'json': 'true'
-                        }
-                        headers = {'User-Agent': LitAgent().random()}
+                    with open(tmp_path, "rb") as f:
+                        files = {"fileToUpload": (f"image.{ext}", f, f"image/{ext}")}
+                        data = {"reqtype": "fileupload", "json": "true"}
+                        headers = {"User-Agent": LitAgent().random()}
                         if attempt > 0:
-                            headers['Connection'] = 'close'
-                        resp = requests.post("https://catbox.moe/user/api.php", files=files, data=data, headers=headers, timeout=timeout)
+                            headers["Connection"] = "close"
+                        resp = requests.post(
+                            "https://catbox.moe/user/api.php",
+                            files=files,
+                            data=data,
+                            headers=headers,
+                            timeout=timeout,
+                        )
                         if resp.status_code == 200 and resp.text.strip():
                             text = resp.text.strip()
-                            if text.startswith('http'):
+                            if text.startswith("http"):
                                 return text
                             try:
                                 result = resp.json()
                                 if "url" in result:
                                     return result["url"]
                             except json.JSONDecodeError:
-                                if 'http' in text:
+                                if "http" in text:
                                     return text
                 except Exception:
                     if attempt < max_retries - 1:
@@ -97,12 +105,12 @@ class Images(BaseImages):
                 try:
                     if not os.path.isfile(tmp_path):
                         return None
-                    with open(tmp_path, 'rb') as img_file:
-                        files = {'file': img_file}
-                        response = requests.post('https://0x0.st', files=files)
+                    with open(tmp_path, "rb") as img_file:
+                        files = {"file": img_file}
+                        response = requests.post("https://0x0.st", files=files)
                         response.raise_for_status()
                         image_url = response.text.strip()
-                        if not image_url.startswith('http'):
+                        if not image_url.startswith("http"):
                             return None
                         return image_url
                 except Exception:
@@ -116,22 +124,29 @@ class Images(BaseImages):
                 return None
 
         for _ in range(n):
-            resp = self._client.session.post(
+            resp = request_with_proxy_fallback(
+                self._client.session,
+                "post",
                 self._client.api_endpoint,
                 json={
                     "prompt": prompt,
                     "model": model,
                     "style": style,
-                    "aspect_ratio": aspect_ratio
+                    "aspect_ratio": aspect_ratio,
                 },
-                timeout=timeout
+                timeout=timeout,
             )
             resp.raise_for_status()
             data = resp.json()
-            
-            if 'output' in data and len(data['output']) > 0:
-                image_url = data['output'][0]
-                img_resp = self._client.session.get(image_url, timeout=timeout)
+
+            if "output" in data and len(data["output"]) > 0:
+                image_url = data["output"][0]
+                img_resp = request_with_proxy_fallback(
+                    self._client.session,
+                    "get",
+                    image_url,
+                    timeout=timeout,
+                )
                 img_resp.raise_for_status()
                 webp_bytes = img_resp.content
 
@@ -151,15 +166,17 @@ class Images(BaseImages):
                 if response_format == "url":
                     # Try primary upload method with retries
                     uploaded_url = upload_file_with_retry(img_bytes, image_format)
-                    
+
                     # If primary method fails, try alternative
                     if not uploaded_url:
                         uploaded_url = upload_file_alternative(img_bytes, image_format)
-                    
+
                     if uploaded_url:
                         urls.append(uploaded_url)
                     else:
-                        raise RuntimeError("Failed to upload image to catbox.moe using all available methods")
+                        raise RuntimeError(
+                            "Failed to upload image to catbox.moe using all available methods"
+                        )
             else:
                 raise RuntimeError("No image data received from PixelMuse")
 
@@ -169,6 +186,7 @@ class Images(BaseImages):
                 result_data.append(ImageData(url=url))
         elif response_format == "b64_json":
             import base64
+
             for img in images:
                 b64 = base64.b64encode(img).decode("utf-8")
                 result_data.append(ImageData(b64_json=b64))
@@ -176,18 +194,12 @@ class Images(BaseImages):
             raise ValueError("response_format must be 'url' or 'b64_json'")
 
         from time import time as _time
-        return ImageResponse(
-            created=int(_time()),
-            data=result_data
-        )
+
+        return ImageResponse(created=int(_time()), data=result_data)
+
 
 class PixelMuse(TTICompatibleProvider):
-    AVAILABLE_MODELS = [
-        "flux-schnell",
-        "imagen-3-fast",
-        "imagen-3",
-        "recraft-v3"
-    ]
+    AVAILABLE_MODELS = ["flux-schnell", "imagen-3-fast", "imagen-3", "recraft-v3"]
 
     def __init__(self):
         self.api_endpoint = "https://www.pixelmuse.studio/api/predictions"
@@ -209,11 +221,14 @@ class PixelMuse(TTICompatibleProvider):
         class _ModelList:
             def list(inner_self):
                 return type(self).AVAILABLE_MODELS
+
         return _ModelList()
+
 
 # Example usage:
 if __name__ == "__main__":
     from rich import print
+
     client = PixelMuse()
     response = client.images.create(
         model="flux-schnell",

--- a/webscout/Provider/TTI/utils.py
+++ b/webscout/Provider/TTI/utils.py
@@ -1,10 +1,60 @@
-from typing import List, Optional
-from pydantic import BaseModel, Field
 import time
+from typing import List, Optional
+
+import requests
+from pydantic import BaseModel, Field
+
+from webscout.Provider.OPENAI.autoproxy import get_auto_proxy
+
+
+def request_with_proxy_fallback(
+    session: requests.Session,
+    method: str,
+    url: str,
+    *,
+    timeout: Optional[int] = None,
+    retries: int = 3,
+    **kwargs,
+) -> requests.Response:
+    """Perform a request using rotating proxies.
+
+    The request first uses the session's current proxy configuration. If the
+    request fails due to connectivity issues, a new proxy is fetched using
+    :func:`get_auto_proxy` and the request is retried. This continues up to
+    ``retries`` times before raising an exception.
+    """
+
+    if retries < 1:
+        retries = 1
+
+    last_error: Exception | None = None
+    for attempt in range(retries):
+        try:
+            resp = session.request(method, url, timeout=timeout, **kwargs)
+            resp.raise_for_status()
+            return resp
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ProxyError,
+            requests.exceptions.Timeout,
+        ) as exc:
+            last_error = exc
+            try:
+                proxy = get_auto_proxy()
+                session.proxies.update({"http": proxy, "https": proxy})
+            except Exception as fetch_err:  # pragma: no cover - network dependent
+                last_error = fetch_err
+        except Exception:
+            # Other errors should not trigger proxy retry
+            raise
+
+    raise RuntimeError(f"All proxy attempts failed: {last_error}")
+
 
 class ImageData(BaseModel):
     url: Optional[str] = None
     b64_json: Optional[str] = None
+
 
 class ImageResponse(BaseModel):
     created: int = Field(default_factory=lambda: int(time.time()))


### PR DESCRIPTION
## Summary
- verify proxies when fetching from ProxyFox
- retry requests with new proxies on failure

## Testing
- `ruff check webscout/Provider/TTI/utils.py webscout/Provider/OPENAI/autoproxy.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cloudscraper')*

------
https://chatgpt.com/codex/tasks/task_b_683d2b735bb083278874be4819ce945d