### PR TITLE
feat: add SerpBase (Google) search engine via REST API

### DIFF
--- a/llm4free/search/__init__.py
+++ b/llm4free/search/__init__.py
@@ -7,6 +7,7 @@ from .duckduckgo_main import DuckDuckGoSearch
 
 # Import new search engines
 from .engines.mojeek import Mojeek
+from .engines.serpbase import SerpBase
 from .engines.wikipedia import Wikipedia
 
 # Import result models
@@ -30,6 +31,7 @@ __all__ = [
     "YahooSearch",
     # Individual engines
     "Mojeek",
+    "SerpBase",
     "Wikipedia",
     # Result models
     "TextResult",

--- a/llm4free/search/engines/__init__.py
+++ b/llm4free/search/engines/__init__.py
@@ -25,6 +25,7 @@ from .duckduckgo import (
     DuckDuckGoWeather,
 )
 from .mojeek import Mojeek
+from .serpbase import SerpBase
 from .wikipedia import Wikipedia
 from .yahoo import (
     YahooImages,
@@ -40,6 +41,7 @@ ENGINES = {
     "text": {
         "brave": BraveTextSearch,
         "mojeek": Mojeek,
+        "serpbase": SerpBase,
         "bing": BingTextSearch,
         "duckduckgo": DuckDuckGoTextSearch,
         "yahoo": YahooText,
@@ -89,6 +91,7 @@ __all__ = [
     "BraveNews",
     "BraveSuggestions",
     "Mojeek",
+    "SerpBase",
     "Wikipedia",
     "BingBase",
     "BingTextSearch",

--- a/llm4free/search/engines/serpbase.py
+++ b/llm4free/search/engines/serpbase.py
@@ -1,0 +1,113 @@
+"""SerpBase search engine — Google search results via REST API.
+
+This engine provides Google search results through the SerpBase API,
+requiring no scraping maintenance. Set SERPBASE_API_KEY to enable it;
+when the key is missing the engine silently returns an empty list so
+other engines continue unaffected.
+
+Documentation: https://serpbase.dev
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from ..base import BaseSearchEngine
+from ..results import TextResult
+
+logger = logging.getLogger(__name__)
+
+API_URL = "https://api.serpbase.dev/google/search"
+
+
+class SerpBase(BaseSearchEngine[TextResult]):
+    """Google search engine backed by the SerpBase REST API.
+
+    Requires the environment variable ``SERPBASE_API_KEY`` to be set.
+    Get a free key (100 searches, no credit card) at https://serpbase.dev.
+    """
+
+    name = "serpbase"
+    category = "text"
+    provider = "google"
+
+    search_url = API_URL
+    search_method = "GET"
+
+    # XPath fields are unused — this engine fetches structured JSON.
+    items_xpath = ""
+    elements_xpath: dict[str, str] = {}
+
+    def build_payload(
+        self,
+        query: str,
+        region: str,
+        safesearch: str,
+        timelimit: str | None,
+        page: int = 1,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Build query parameters for the SerpBase API."""
+        num = kwargs.pop("num", 10)
+        return {"q": query, "num": num, "api_key": self._api_key}
+
+    @property
+    def _api_key(self) -> str:
+        """Read the API key from environment once per instance."""
+        if not hasattr(self, "_cached_api_key"):
+            self._cached_api_key = os.environ.get("SERPBASE_API_KEY", "")
+        return self._cached_api_key
+
+    def search(
+        self,
+        query: str,
+        region: str = "us-en",
+        safesearch: str = "moderate",
+        timelimit: str | None = None,
+        page: int = 1,
+        **kwargs: Any,
+    ) -> list[TextResult]:
+        """Run a Google text search via the SerpBase API.
+
+        Returns an empty list when ``SERPBASE_API_KEY`` is not set so that
+        other engines are unaffected.  API errors are logged and also result
+        in an empty list rather than raising.
+        """
+        if not self._api_key:
+            logger.warning(
+                "SERPBASE_API_KEY not set — skipping SerpBase. "
+                "Get a free key at https://serpbase.dev"
+            )
+            return []
+
+        num = kwargs.pop("num", 10)
+        params: dict[str, Any] = {
+            "q": query,
+            "num": num,
+            "api_key": self._api_key,
+        }
+
+        try:
+            resp = self.http_client.client.get(
+                self.search_url,
+                params=params,
+                timeout=kwargs.pop("timeout", 30),
+            )
+            resp.raise_for_status()
+            data: dict[str, Any] = resp.json()
+        except Exception:
+            logger.exception("SerpBase API request failed for query=%r", query)
+            return []
+
+        results: list[TextResult] = []
+        for item in data.get("organic_results", []):
+            results.append(
+                TextResult(
+                    title=item.get("title", ""),
+                    href=item.get("link", ""),
+                    body=item.get("snippet", ""),
+                )
+            )
+        return results


### PR DESCRIPTION
## Summary
Add SerpBase as a Google search engine — returns structured Google results via REST API with zero scraping maintenance.

## Background
LLM4Free currently supports Brave, Bing, DuckDuckGo, Mojeek, Yahoo, and Wikipedia — but **no Google**. Google is the most widely used search engine, and many users need its results for research, fact-checking, and AI-agent workflows. SerpBase fills this gap with a lightweight API-based engine instead of fragile HTML scraping.

## Changes
- **New**: `llm4free/search/engines/serpbase.py` — REST API-based engine (113 lines)
- **Updated**: `llm4free/search/engines/__init__.py` — registered as `"serpbase"` in text engines + `__all__`
- **Updated**: `llm4free/search/__init__.py` — added import and export

## Design decisions
| Decision | Rationale |
|----------|-----------|
| API key via `SERPBASE_API_KEY` env var | Matches standard practice for API-based engines |
| Graceful skip when key missing | Logs warning, returns `[]` — other engines continue unaffected |
| Reuses existing `curl_cffi` HTTP client | No new dependencies |
| Named `"serpbase"` in registry | Distinct from a hypothetical scraping-based `"google"` engine, keeps namespace clean |
| Overrides `search()` directly | Avoids XPath machinery that's irrelevant for JSON API results |

## Testing
- With `SERPBASE_API_KEY` set: returns Google search results as `TextResult` list
- Without key: logs warning, returns `[]`, other engines unaffected
- API errors (network, auth, rate-limit): caught and logged, returns `[]` gracefully
- No modification to existing engine behavior